### PR TITLE
Fix: PG19 compatibility for pg_orphaned

### DIFF
--- a/pg_orphaned.c
+++ b/pg_orphaned.c
@@ -14,6 +14,7 @@
 #include "funcapi.h"
 #include "utils/builtins.h"
 #include <sys/stat.h>
+#include <dirent.h>
 #if PG_VERSION_NUM < 190000
 #include "commands/dbcommands.h"
 #else
@@ -21,11 +22,9 @@
 #include "utils/lsyscache.h"
 #endif
 #include "regex/regex.h"
-
-#if PG_VERSION_NUM < 100000
-#include <dirent.h>
 #include "storage/fd.h"
-#endif
+#include "utils/hsearch.h"
+#include "utils/tuplestore.h"
 
 #if PG_VERSION_NUM < 110000
 #include "catalog/pg_collation.h"


### PR DESCRIPTION
PG19 no longer transitively includes several headers that pg_orphaned depends on. 

Three changes:

dirent.h — was behind #if PG_VERSION_NUM < 100000 guard, but PG19 stopped pulling it in through server headers. Moved to unconditional include. Provides DIR, struct dirent, opendir(), readdir(), closedir().

 
Added hsearch.h
provides HASHCTL, HASH_ELEM, HASH_BLOBS, HASH_CONTEXT, HASH_FIND, HASH_ENTER, HASH_REMOVE, HASH_SEQ_STATUS, hash_create(), hash_search(), hash_seq_init(), hash_seq_search().


Added tuplestore.h
provides tuplestore_begin_heap(), tuplestore_putvalues().